### PR TITLE
feat: add NewEventTToAnyAdapter constructor and refactor adapter usage

### DIFF
--- a/event.go
+++ b/event.go
@@ -268,6 +268,13 @@ type EventTToAnyAdapter[T any] struct {
 	OriginalEvent Event[T]
 }
 
+// NewEventTToAnyAdapter creates a new adapter for converting Event[T] to Event[any]
+func NewEventTToAnyAdapter[T any](original Event[T]) *EventTToAnyAdapter[T] {
+	return &EventTToAnyAdapter[T]{
+		OriginalEvent: original,
+	}
+}
+
 func (eta *EventTToAnyAdapter[T]) Name() string { return eta.OriginalEvent.Name() }
 func (eta *EventTToAnyAdapter[T]) Data() any    { return eta.OriginalEvent.Data() } // Event[T].Data() returns T, assignable to any
 func (eta *EventTToAnyAdapter[T]) SetData(d any) (Event[any], error) {

--- a/std.go
+++ b/std.go
@@ -83,7 +83,7 @@ func (a *StdManagerAdapter[T]) FireBatch(events ...any) []error {
 	converted := make([]any, len(events))
 	for i, e := range events {
 		if evt, ok := e.(Event[T]); ok {
-			converted[i] = &EventTToAnyAdapter[T]{OriginalEvent: evt}
+			converted[i] = NewEventTToAnyAdapter(evt)
 		} else {
 			converted[i] = e
 		}
@@ -116,7 +116,7 @@ func (a *StdManagerAdapter[T]) AsyncFire(e Event[T]) {
 }
 
 func (a *StdManagerAdapter[T]) AwaitFire(e Event[T]) error {
-	return a.Mgr.AwaitFire(&EventTToAnyAdapter[T]{OriginalEvent: e})
+	return a.Mgr.AwaitFire(NewEventTToAnyAdapter(e))
 }
 
 func (a *StdManagerAdapter[T]) CloseWait() error {
@@ -248,7 +248,7 @@ func StdForType[T any]() EventManager[T] {
 func (a *StdManagerAdapter[T]) AddEventFc(name string, fc FactoryFunc[T]) {
 	a.Mgr.AddEventFc(name, func() Event[any] {
 		e := fc()
-		return &EventTToAnyAdapter[T]{OriginalEvent: e}
+		return NewEventTToAnyAdapter(e)
 	})
 }
 
@@ -376,7 +376,7 @@ func Subscribe[T any](mgr *Manager[T], sbr Subscriber[T]) {
 
 // AsyncFire simple async fire event by 'go' keywords
 func AsyncFire[T any](e Event[T]) {
-	adaptedEventForStd := &EventTToAnyAdapter[T]{OriginalEvent: e}
+	adaptedEventForStd := NewEventTToAnyAdapter(e)
 	std.AsyncFire(adaptedEventForStd)
 }
 
@@ -387,7 +387,7 @@ func Async[T any](name string, data T) {
 
 // FireAsync fire event by channel
 func FireAsync[T any](e Event[T]) {
-	adaptedEventForStd := &EventTToAnyAdapter[T]{OriginalEvent: e}
+	adaptedEventForStd := NewEventTToAnyAdapter(e)
 	std.FireAsync(adaptedEventForStd)
 }
 
@@ -439,7 +439,7 @@ func Fire[T any](name string, data T) (error, Event[T]) {
 
 // FireEvent fire listeners by Event instance.
 func FireEvent[T any](e Event[T]) error {
-	adaptedEventForStd := &EventTToAnyAdapter[T]{OriginalEvent: e}
+	adaptedEventForStd := NewEventTToAnyAdapter(e)
 	return std.FireEvent(adaptedEventForStd)
 }
 
@@ -483,7 +483,7 @@ func Reset() {
 
 // AddEvent add a pre-defined event.
 func AddEvent[T any](e Event[T]) {
-	adaptedEventForStd := &EventTToAnyAdapter[T]{OriginalEvent: e}
+	adaptedEventForStd := NewEventTToAnyAdapter(e)
 	std.AddEvent(adaptedEventForStd)
 }
 


### PR DESCRIPTION
- Added NewEventTToAnyAdapter constructor function to create EventTToAnyAdapter instances
- Refactored all direct EventTToAnyAdapter struct initializations to use the new constructor
- Changes applied consistently across event.go and std.go files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated event adapter creation to use a new constructor function, improving consistency in how event adapters are instantiated. No changes to event behavior or user-facing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->